### PR TITLE
Vendor HID for upgrades (#529)

### DIFF
--- a/docs/boards/nrf52840dk.md
+++ b/docs/boards/nrf52840dk.md
@@ -70,3 +70,11 @@ respectively. You can only upgrade the partition that is not currently running,
 so always alternate your calls to `perform_upgrade.sh`. Otherwise, this script
 works like `deploy.py`. You can call it even after you locked down your device,
 to deploy changes to your development board.
+
+If you deploy with `--vendor-hid`, also add this flag to `perform_upgrade.sh`,
+for example:
+
+```shell
+./deploy.py --board=nrf52840dk_opensk_a --opensk --vendor-hid
+./tools/perform_upgrade.sh nrf52840dk_opensk_b --vendor-hid
+```

--- a/tools/configure.py
+++ b/tools/configure.py
@@ -212,10 +212,10 @@ if __name__ == "__main__":
             "haven't been both programmed yet."),
   )
   parser.add_argument(
-      "--use-vendor-hid",
+      "--vendor-hid",
       default=False,
       action="store_true",
       dest="use_vendor_hid",
-      help=("Whether to configure the device using the Vendor HID interface"),
+      help=("Whether to configure the device using the Vendor HID interface."),
   )
   main(parser.parse_args())

--- a/tools/deploy_partition.py
+++ b/tools/deploy_partition.py
@@ -25,6 +25,7 @@ import hashlib
 import os
 import struct
 from typing import Any
+from unittest.mock import patch
 import uuid
 
 import colorama
@@ -172,7 +173,16 @@ def main(args):
       "signature": sign_firmware(signed_data, priv_key)
   }
 
-  for authenticator in tqdm(get_opensk_devices(args.batch)):
+  if args.use_vendor_hid:
+    patcher = patch.object(hid.base, "FIDO_USAGE_PAGE", 0xFF00)
+    patcher.start()
+    info("Using the Vendor HID interface")
+
+  devices = get_opensk_devices(args.batch)
+
+  if not devices:
+    fatal("No devices found.")
+  for authenticator in tqdm(devices):
     # If the device supports it, wink to show which device we upgrade.
     if authenticator.device.capabilities & hid.CAPABILITY.WINK:
       authenticator.device.wink()
@@ -241,5 +251,12 @@ if __name__ == "__main__":
       default="crypto_data/opensk_upgrade.key",
       dest="priv_key",
       help=("PEM file for signing the firmware."),
+  )
+  parser.add_argument(
+      "--vendor-hid",
+      default=False,
+      action="store_true",
+      dest="use_vendor_hid",
+      help=("Whether to upgrade the device using the Vendor HID interface."),
   )
   main(parser.parse_args())

--- a/tools/perform_upgrade.sh
+++ b/tools/perform_upgrade.sh
@@ -22,8 +22,8 @@ set -e
 
 BOARD="$1"
 
-./deploy.py --board=$BOARD --opensk --programmer=none
-python3 -m tools.deploy_partition --board=$BOARD
+./deploy.py --board="${BOARD}" --opensk --programmer=none $2
+python3 -m tools.deploy_partition --board="${BOARD}" $2
 if nrfjprog --reset --family NRF52 ; then
   echo "Upgrade finished!"
 else


### PR DESCRIPTION
* vendor-hid for upgrades

* empty argument fix

* same vendor-hid usage in both deploys

* forgot one board

* aaand also forgot the quotes

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

-   [ ] Local tests pass (running `run_desktop_tests.sh`)
-   [ ] Tested against boards
    -   [ ] Nordic nRF52840 DK
    -   [ ] Nordic nRF52840 Dongle (JTAG programmed)
    -   [ ] Nordic nRF52840 Dongle (DFU programmed)
    -   [ ] Makerdiary nRF52840 MDK USB Dongle
-   [ ] Appropriate changes to README are included in PR
